### PR TITLE
Byte buffer

### DIFF
--- a/cli/src/main/java/com/dexesttp/hkxpack/cli/TestView.java
+++ b/cli/src/main/java/com/dexesttp/hkxpack/cli/TestView.java
@@ -12,7 +12,7 @@ import com.dexesttp.hkxpack.tagreader.TagXMLReader;
 import com.dexesttp.hkxpack.tagwriter.TagXMLWriter;
 
 public class TestView {
-	private static final String testName = "Locomotion";
+	private static final String testName = "StaggerLarge";
 	public static void main(String[] args) {
 		read(args, testName);
 		write(args);
@@ -20,8 +20,10 @@ public class TestView {
 	}
 	
 	public static void read(String[] args, String name) {
-		String inputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + name + ".hkx";
-		String outputFileName =  "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + name + ".xml";
+		//String inputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + name + ".hkx";
+		//String outputFileName =  "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + name + ".xml";
+		String inputFileName = "c:\\temp\\hkx\\" + name + ".hkx";
+		String outputFileName =  "c:\\temp\\hkx\\" + name + ".xml";
 		DisplayProperties.displayDebugInfo = true;
 		DisplayProperties.displayFileDebugInfo = true;
 		DisplayProperties.displayReadTypesInfo = true;
@@ -45,8 +47,10 @@ public class TestView {
 	}
 	
 	public static void write(String[] args) {
-		String inputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + testName + ".xml";
-		String outputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + testName + "-new.hkx";
+		//String inputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + testName + ".xml";
+		//String outputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + testName + "-new.hkx";
+		String inputFileName = "c:\\temp\\hkx\\" + testName + ".xml";
+		String outputFileName = "c:\\temp\\hkx\\" + testName + "-new.hkx";
 		DisplayProperties.displayDebugInfo = true;
 		DisplayProperties.displayFileDebugInfo = true;
 		DisplayProperties.displayReadTypesInfo = true;
@@ -70,8 +74,8 @@ public class TestView {
 	}
 	
 	public static void xmlTest(String[] args) {
-		String inputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + testName + ".xml";
-		String outputFileName = "D:\\Documents\\SANDBOX\\FO4\\hkx_files\\" + testName + "-new.xml";
+		String inputFileName = "c:\\temp\\hkx\\" + testName + ".xml";
+		String outputFileName = "c:\\temp\\hkx\\" + testName + "-new.xml";
 		DisplayProperties.displayDebugInfo = true;
 		DisplayProperties.displayFileDebugInfo = true;
 		DisplayProperties.displayReadTypesInfo = true;

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/classnames/ClassnamesInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/classnames/ClassnamesInterface.java
@@ -1,31 +1,38 @@
 package com.dexesttp.hkxpack.hkx.classnames;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map.Entry;
 
+import com.dexesttp.hkxpack.hkx.header.HeaderData;
 import com.dexesttp.hkxpack.hkx.header.SectionData;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
+/**
+ * Connects to a {@link ByteBuffer}, and allows easy retrieval and writing of {@link ClassnamesData}.
+ */
 public class ClassnamesInterface {
 	private ByteBuffer file;
 	private SectionData section;
 	
-	public void connect(ByteBuffer file, SectionData classnameSection) throws FileNotFoundException {
+	/**
+	 * Connect to a given {@link ByteBuffer}, based on the given {@link SectionData}.
+	 * @param file the {@link ByteBuffer} to connect to.
+	 * @param header the {@link HeaderData} to base the search on.
+	 */
+	public void connect(ByteBuffer file, SectionData classnameSection) {
 		this.file = file;
 		this.section = classnameSection;
 	}
 	
 	/**
 	 * Compress the given classnames into the hkx file "__classname__" section.
-	 * Note taht it will fill the data with all required classnames & positions.
-	 * Please use only negative position identifiers to fill the original dataset values. Otherwise, the fi=unction comprtement will be indetermined.
+	 * Note that it will fill the data with all required classnames & positions.
+	 * Please use only negative position identifiers to fill the original dataset values. 
+	 * Otherwise, the function compartment will be indeterminate.
 	 * @param data the data to find the classnames in.
 	 * @return The position of the end of the dataset (absolute position from the beginning of the file).
-	 * @throws IOException
 	 */
-	public long compress(ClassnamesData data) throws IOException {
+	public long compress(ClassnamesData data) {
 		file.position((int) section.offset);
 		for(Entry<Long, Classname> classData : data.entrySet()) {
 			file.put(classData.getValue().uuid);
@@ -42,7 +49,7 @@ public class ClassnamesInterface {
 		return pos + toDo;
 	}
 	
-	public ClassnamesData extract() throws IOException {
+	public ClassnamesData extract() {
 		final long limit = section.offset + section.data1;
 		ClassnamesData data = new ClassnamesData();
 		byte[] idList = new byte[4];
@@ -61,7 +68,10 @@ public class ClassnamesInterface {
 		return data;
 	}
 
-	/*public void close() throws IOException {
-		file.close();
-	}*/
+	/**
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
+	 */
+	public void close() {
+
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data1Interface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data1Interface.java
@@ -3,7 +3,7 @@ package com.dexesttp.hkxpack.hkx.data;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 import com.dexesttp.hkxpack.hkx.header.SectionData;
@@ -13,7 +13,7 @@ import com.dexesttp.hkxpack.resources.ByteUtils;
  * Interface on the Data1 section of a HKX File.
  */
 public class Data1Interface {
-	private RandomAccessFile file;
+	private ByteBuffer file;
 	private SectionData header;
 	private int lastPos = -1;
 
@@ -23,8 +23,8 @@ public class Data1Interface {
 	 * @param dataHeader the {@link SectionData} relative to the Data section.
 	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(File file, SectionData dataHeader) throws FileNotFoundException {
-		this.file = new RandomAccessFile(file, "rw");
+	public void connect(ByteBuffer file, SectionData dataHeader) throws FileNotFoundException {
+		this.file = file;
 		this.header = dataHeader;
 	}
 
@@ -40,13 +40,13 @@ public class Data1Interface {
 		long dataPos = header.data1 + pos * 0x08;
 		if(pos < 0 || dataPos > header.data2)
 			throw new InvalidPositionException("DATA_1", pos );
-		file.seek(header.offset + dataPos);
+		file.position((int) (header.offset + dataPos));
 		byte[] dataLine = new byte[4];
-		file.read(dataLine);
+		file.get(dataLine);
 		data.from = ByteUtils.getLong(dataLine);
 		if(data.from > header.offset + header.data1)
 			throw new InvalidPositionException("DATA_1", pos );
-		file.read(dataLine);
+		file.get(dataLine);
 		data.to = ByteUtils.getLong(dataLine);
 		this.lastPos  = pos;
 		return data;
@@ -61,9 +61,9 @@ public class Data1Interface {
 	 */
 	public long write(int pos, DataInternal internal) throws IOException {
 		long dataPos = header.data1 + pos * 0x08;
-		file.seek(header.offset + dataPos);
-		file.write(ByteUtils.fromLong(internal.from, 4));
-		file.write(ByteUtils.fromLong(internal.to, 4));
+		file.position((int) (header.offset + dataPos));
+		file.put(ByteUtils.fromLong(internal.from, 4));
+		file.put(ByteUtils.fromLong(internal.to, 4));
 		return dataPos + 0x08;
 	}
 
@@ -88,7 +88,7 @@ public class Data1Interface {
 	 * Close this {@link Data1Interface} connection with the {@link File}.
 	 * @throws IOException
 	 */
-	public void close() throws IOException {
+/*	public void close() throws IOException {
 		file.close();
-	}
+	}*/
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data1Interface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data1Interface.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkx.data;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -10,7 +8,7 @@ import com.dexesttp.hkxpack.hkx.header.SectionData;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 /**
- * Interface on the Data1 section of a HKX File.
+ * Interface on the Data1 section of a HKX File {@link ByteBuffer}.
  */
 public class Data1Interface {
 	private ByteBuffer file;
@@ -18,24 +16,22 @@ public class Data1Interface {
 	private int lastPos = -1;
 
 	/**
-	 * Connect this {@link Data1Interface} to a {@link File}.
-	 * @param file the {@link File} to connect to.
+	 * Connect this {@link Data1Interface} to a {@link ByteBuffer}.
+	 * @param file the {@link ByteBuffer} to connect to.
 	 * @param dataHeader the {@link SectionData} relative to the Data section.
-	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(ByteBuffer file, SectionData dataHeader) throws FileNotFoundException {
+	public void connect(ByteBuffer file, SectionData dataHeader) {
 		this.file = file;
 		this.header = dataHeader;
 	}
 
 	/**
-	 * Read a given Internal data component from the file.
+	 * Read a given Internal data component from the file {@link ByteBuffer}.
 	 * @param pos the position of the wanted {@link DataInternal} component.
 	 * @return the read {@link DataInternal}.
-	 * @throws IOException if the file couldn't be read.
 	 * @throws InvalidPositionException if the requested position was outside the Data1 section.
 	 */
-	public DataInternal read(int pos) throws IOException, InvalidPositionException {
+	public DataInternal read(int pos) throws InvalidPositionException {
 		DataInternal data = new DataInternal();
 		long dataPos = header.data1 + pos * 0x08;
 		if(pos < 0 || dataPos > header.data2)
@@ -53,13 +49,12 @@ public class Data1Interface {
 	}
 
 	/**
-	 * Writes the given Internal data to the file, at the given position.
+	 * Writes the given Internal data to the file {@link ByteBuffer}, at the given position.
 	 * @param pos the position to write the data to.
 	 * @param internal the {@link DataInternal} to write.
 	 * @return the position of the end of the {@link DataInternal}.
-	 * @throws IOException if there was a problem while writing to the file.
 	 */
-	public long write(int pos, DataInternal internal) throws IOException {
+	public long write(int pos, DataInternal internal) {
 		long dataPos = header.data1 + pos * 0x08;
 		file.position((int) (header.offset + dataPos));
 		file.put(ByteUtils.fromLong(internal.from, 4));
@@ -70,10 +65,9 @@ public class Data1Interface {
 	/**
 	 * Reads the next element from the Data1 section.
 	 * @return The requested {@link DataInternal}
-	 * @throws IOException if there was a problem reading the file.
 	 * @throws InvalidPositionException If the next element doesn't exist.
 	 */
-	public DataInternal readNext() throws IOException, InvalidPositionException {
+	public DataInternal readNext() throws InvalidPositionException {
 		return read(++lastPos);
 	}
 
@@ -85,10 +79,8 @@ public class Data1Interface {
 	}
 
 	/**
-	 * Close this {@link Data1Interface} connection with the {@link File}.
-	 * @throws IOException
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-/*	public void close() throws IOException {
-		file.close();
-	}*/
+	public void close() throws IOException {
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data2Interface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data2Interface.java
@@ -3,7 +3,7 @@ package com.dexesttp.hkxpack.hkx.data;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 import com.dexesttp.hkxpack.hkx.header.SectionData;
@@ -13,7 +13,7 @@ import com.dexesttp.hkxpack.resources.ByteUtils;
  * Interface on the Data2 section of a HKX file.
  */
 public class Data2Interface {
-	private RandomAccessFile file;
+	private ByteBuffer file;
 	private SectionData header;
 	private int lastPos = -1;
 
@@ -23,8 +23,8 @@ public class Data2Interface {
 	 * @param dataHeader the {@link SectionData} relative to the Data section.
 	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(File file, SectionData data1) throws FileNotFoundException {
-		this.file = new RandomAccessFile(file, "rw");
+	public void connect(ByteBuffer file, SectionData data1) throws FileNotFoundException {
+		this.file = file;
 		this.header = data1;
 	}
 
@@ -40,15 +40,15 @@ public class Data2Interface {
 		long dataPos = header.data2 + pos * 0x0C;
 		if(pos < 0 || dataPos > header.data3)
 			throw new InvalidPositionException("DATA_2", pos );
-		file.seek(header.offset + dataPos);
+		file.position((int) (header.offset + dataPos));
 		byte[] dataLine = new byte[4];
-		file.read(dataLine);
+		file.get(dataLine);
 		data.from = ByteUtils.getLong(dataLine);
-		file.read(dataLine);
+		file.get(dataLine);
 		data.section = ByteUtils.getInt(dataLine);
 		if(data.section > header.offset + header.data1)
 			throw new InvalidPositionException("DATA_2", pos );
-		file.read(dataLine);
+		file.get(dataLine);
 		data.to = ByteUtils.getLong(dataLine);
 		lastPos = pos;
 		return data;
@@ -63,10 +63,10 @@ public class Data2Interface {
 	 */
 	public long write(int pos, DataExternal data) throws IOException {
 		long dataPos = header.data2 + pos * 0x0C;
-		file.seek(header.offset + dataPos);
-		file.write(ByteUtils.fromLong(data.from, 4));
-		file.write(ByteUtils.fromLong(data.section, 4));
-		file.write(ByteUtils.fromLong(data.to, 4));
+		file.position((int) (header.offset + dataPos));
+		file.put(ByteUtils.fromLong(data.from, 4));
+		file.put(ByteUtils.fromLong(data.section, 4));
+		file.put(ByteUtils.fromLong(data.to, 4));
 		return dataPos + 0x0C;
 	}
 
@@ -91,7 +91,7 @@ public class Data2Interface {
 	 * Close this {@link Data2Interface} connection with the {@link File}.
 	 * @throws IOException
 	 */
-	public void close() throws IOException {
+	/*public void close() throws IOException {
 		file.close();
-	}
+	}*/
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data2Interface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data2Interface.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkx.data;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -10,7 +8,7 @@ import com.dexesttp.hkxpack.hkx.header.SectionData;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 /**
- * Interface on the Data2 section of a HKX file.
+ * Interface on the Data2 section of a HKX file {@link ByteBuffer}.
  */
 public class Data2Interface {
 	private ByteBuffer file;
@@ -18,24 +16,22 @@ public class Data2Interface {
 	private int lastPos = -1;
 
 	/**
-	 * Connect this {@link Data2Interface} to a {@link File}.
-	 * @param file the {@link File} to connect to.
+	 * Connect this {@link Data2Interface} to a {@link ByteBuffer}.
+	 * @param file the {@link ByteBuffer} to connect to.
 	 * @param dataHeader the {@link SectionData} relative to the Data section.
-	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(ByteBuffer file, SectionData data1) throws FileNotFoundException {
+	public void connect(ByteBuffer file, SectionData data1) {
 		this.file = file;
 		this.header = data1;
 	}
 
 	/**
-	 * Read a given External data component from the file.
+	 * Read a given External data component from the file {@link ByteBuffer}.
 	 * @param pos the position of the wanted {@link DataExternal} component.
 	 * @return the read {@link DataExternal}.
-	 * @throws IOException if the file couldn't be read.
 	 * @throws InvalidPositionException if the requested position was outside the Data2 section.
 	 */
-	public DataExternal read(int pos) throws IOException, InvalidPositionException {
+	public DataExternal read(int pos) throws InvalidPositionException {
 		DataExternal data = new DataExternal();
 		long dataPos = header.data2 + pos * 0x0C;
 		if(pos < 0 || dataPos > header.data3)
@@ -61,7 +57,7 @@ public class Data2Interface {
 	 * @return the position as section offset of the end of the written {@link DataExternal}.
 	 * @throws IOException if there was a problem writing to the file.
 	 */
-	public long write(int pos, DataExternal data) throws IOException {
+	public long write(int pos, DataExternal data) {
 		long dataPos = header.data2 + pos * 0x0C;
 		file.position((int) (header.offset + dataPos));
 		file.put(ByteUtils.fromLong(data.from, 4));
@@ -76,7 +72,7 @@ public class Data2Interface {
 	 * @throws IOException if there was a problem reading the file.
 	 * @throws InvalidPositionException If the next element doesn't exist.
 	 */
-	public DataExternal readNext() throws IOException, InvalidPositionException {
+	public DataExternal readNext() throws InvalidPositionException {
 		return read(++lastPos);
 	}
 
@@ -88,10 +84,8 @@ public class Data2Interface {
 	}
 
 	/**
-	 * Close this {@link Data2Interface} connection with the {@link File}.
-	 * @throws IOException
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-	/*public void close() throws IOException {
-		file.close();
-	}*/
+	public void close() {
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data3Interface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data3Interface.java
@@ -3,7 +3,7 @@ package com.dexesttp.hkxpack.hkx.data;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 import com.dexesttp.hkxpack.hkx.header.SectionData;
@@ -13,7 +13,7 @@ import com.dexesttp.hkxpack.resources.ByteUtils;
  * Interface on the Data3 section of a HKX file.
  */
 public class Data3Interface {
-	private RandomAccessFile file;
+	private ByteBuffer file;
 	private SectionData header;
 
 	/**
@@ -22,8 +22,8 @@ public class Data3Interface {
 	 * @param dataHeader the {@link SectionData} relative to the Data section.
 	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(File file, SectionData data1) throws FileNotFoundException {
-		this.file = new RandomAccessFile(file, "rw");
+	public void connect(ByteBuffer file, SectionData data1) throws FileNotFoundException {
+		this.file = file;
 		this.header = data1;
 	}
 
@@ -39,15 +39,15 @@ public class Data3Interface {
 		long dataPos = header.data3 + pos * 0x0C;
 		if(pos < 0 || dataPos >= header.end)
 			throw new InvalidPositionException("DATA_3", pos );
-		file.seek(header.offset + dataPos);
+		file.position((int) (header.offset + dataPos));
 		byte[] dataLine = new byte[4];
-		file.read(dataLine);
+		file.get(dataLine);
 		data.from = ByteUtils.getLong(dataLine);
 		if(data.from > header.offset + header.data1)
 			throw new InvalidPositionException("DATA_3", pos );
-		file.read(dataLine);
+		file.get(dataLine);
 		data.section = ByteUtils.getInt(dataLine);
-		file.read(dataLine);
+		file.get(dataLine);
 		data.to = ByteUtils.getLong(dataLine);
 		return data;
 	}
@@ -61,10 +61,10 @@ public class Data3Interface {
 	 */
 	public long write(int pos, DataExternal data) throws IOException {
 		long dataPos = header.data3 + pos * 0x0C;
-		file.seek(header.offset + dataPos);
-		file.write(ByteUtils.fromLong(data.from, 4));
-		file.write(ByteUtils.fromLong(data.section, 4));
-		file.write(ByteUtils.fromLong(data.to, 4));
+		file.position((int) (header.offset + dataPos));
+		file.put(ByteUtils.fromLong(data.from, 4));
+		file.put(ByteUtils.fromLong(data.section, 4));
+		file.put(ByteUtils.fromLong(data.to, 4));
 		return dataPos + 0x0C;
 	}
 
@@ -72,7 +72,7 @@ public class Data3Interface {
 	 * Close this {@link Data3Interface} connection with the {@link File}.
 	 * @throws IOException
 	 */
-	public void close() throws IOException {
+/*	public void close() throws IOException {
 		file.close();
-	}
+	}*/
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data3Interface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/Data3Interface.java
@@ -1,8 +1,5 @@
 package com.dexesttp.hkxpack.hkx.data;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
@@ -10,19 +7,18 @@ import com.dexesttp.hkxpack.hkx.header.SectionData;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 /**
- * Interface on the Data3 section of a HKX file.
+ * Interface on the Data3 section of a HKX file {@link ByteBuffer}.
  */
 public class Data3Interface {
 	private ByteBuffer file;
 	private SectionData header;
 
 	/**
-	 * Connect this {@link Data3Interface} to a {@link File}.
-	 * @param file the {@link File} to connect to.
+	 * Connect this {@link Data3Interface} to a {@link ByteBuffer}.
+	 * @param file the {@link ByteBuffer} to connect to.
 	 * @param dataHeader the {@link SectionData} relative to the Data section.
-	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(ByteBuffer file, SectionData data1) throws FileNotFoundException {
+	public void connect(ByteBuffer file, SectionData data1) {
 		this.file = file;
 		this.header = data1;
 	}
@@ -31,10 +27,9 @@ public class Data3Interface {
 	 * Read a specific item from the data3 section
 	 * @param pos the position of the item to read
 	 * @return the read DataExternal
-	 * @throws IOException if there is a problem reading the file
 	 * @throws InvalidPositionException if the position of the item isn't valid
 	 */
-	public DataExternal read(int pos) throws IOException, InvalidPositionException {
+	public DataExternal read(int pos) throws InvalidPositionException {
 		DataExternal data = new DataExternal();
 		long dataPos = header.data3 + pos * 0x0C;
 		if(pos < 0 || dataPos >= header.end)
@@ -53,13 +48,12 @@ public class Data3Interface {
 	}
 
 	/**
-	 * Write a given External data to the file at the given position.
+	 * Write a given External data to the file {@link ByteBuffer} at the given position.
 	 * @param pos the position to write the external data at.
 	 * @param data the {@link DataExternal} to write.
 	 * @return the position as section offset of the end of the written {@link DataExternal}.
-	 * @throws IOException if there was a problem writing to the file.
 	 */
-	public long write(int pos, DataExternal data) throws IOException {
+	public long write(int pos, DataExternal data)  {
 		long dataPos = header.data3 + pos * 0x0C;
 		file.position((int) (header.offset + dataPos));
 		file.put(ByteUtils.fromLong(data.from, 4));
@@ -69,10 +63,8 @@ public class Data3Interface {
 	}
 
 	/**
-	 * Close this {@link Data3Interface} connection with the {@link File}.
-	 * @throws IOException
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-/*	public void close() throws IOException {
-		file.close();
-	}*/
+	public void close() {
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/DataInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/DataInterface.java
@@ -1,9 +1,5 @@
 package com.dexesttp.hkxpack.hkx.data;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
@@ -17,12 +13,11 @@ public class DataInterface {
 	private SectionData header;
 
 	/**
-	 * Connect this {@link DataInterface} to a {@link File}, using information from the file's header.
-	 * @param file the {@link File} to connect to.
+	 * Connect this {@link DataInterface} to a {@link ByteBuffer}, using information from the file's header.
+	 * @param file the {@link ByteBuffer} to connect to.
 	 * @param dataHeader the {@link SectionData} information relative to the Data sections.
-	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(ByteBuffer file, SectionData dataHeader) throws FileNotFoundException {
+	public void connect(ByteBuffer file, SectionData dataHeader) {
 		this.file = file;
 		this.header = dataHeader;
 	}
@@ -30,11 +25,10 @@ public class DataInterface {
 	/**
 	 * Setup the file to a specific position.
 	 * @param position the position to setup the file in Data at.
-	 * @return the {@link RandomAccessFile}, at the given position in Data.
+	 * @return the {@link ByteBuffer}, at the given position in Data.
 	 * @throws InvalidPositionException if the position is outside the file's Data definition.
-	 * @throws IOException if the {@link RandomAccessFile} positionnement created an error.
 	 */
-	public ByteBuffer setup(long position) throws IOException, InvalidPositionException {
+	public ByteBuffer setup(long position) throws InvalidPositionException {
 		if(position < 0 || position > header.data1)
 			throw new InvalidPositionException("DATA", position);
 		file.position((int) (header.offset + position));

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/data/DataInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/data/DataInterface.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 import com.dexesttp.hkxpack.hkx.header.SectionData;
@@ -12,7 +13,7 @@ import com.dexesttp.hkxpack.hkx.header.SectionData;
  * Interface to connect to the Data section of the file.
  */
 public class DataInterface {
-	private RandomAccessFile file;
+	private ByteBuffer file;
 	private SectionData header;
 
 	/**
@@ -21,8 +22,8 @@ public class DataInterface {
 	 * @param dataHeader the {@link SectionData} information relative to the Data sections.
 	 * @throws FileNotFoundException if the {@link File} couldn't be opened.
 	 */
-	public void connect(File file, SectionData dataHeader) throws FileNotFoundException {
-		this.file = new RandomAccessFile(file, "rw");
+	public void connect(ByteBuffer file, SectionData dataHeader) throws FileNotFoundException {
+		this.file = file;
 		this.header = dataHeader;
 	}
 	
@@ -33,10 +34,10 @@ public class DataInterface {
 	 * @throws InvalidPositionException if the position is outside the file's Data definition.
 	 * @throws IOException if the {@link RandomAccessFile} positionnement created an error.
 	 */
-	public RandomAccessFile setup(long position) throws IOException, InvalidPositionException {
+	public ByteBuffer setup(long position) throws IOException, InvalidPositionException {
 		if(position < 0 || position > header.data1)
 			throw new InvalidPositionException("DATA", position);
-		file.seek(header.offset + position);
+		file.position((int) (header.offset + position));
 		return file;
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/header/HeaderInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/header/HeaderInterface.java
@@ -1,8 +1,5 @@
 package com.dexesttp.hkxpack.hkx.header;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.UnsupportedVersionError;
@@ -11,27 +8,25 @@ import com.dexesttp.hkxpack.hkx.header.internals.versions.HeaderDescriptor_v11;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 /**
- * Connects to a HKX {@link File} and allows direct access to the header contents.
+ * Connects to a HKX {@link ByteBuffer} and allows direct access to the header contents.
  */
 public class HeaderInterface {
 	private ByteBuffer file;
 
 	/**
-	 * Connect to a {@link File}
-	 * @param file the file to connect to.
-	 * @throws FileNotFoundException If the given file could not be found.
+	 * Connect to a {@link ByteBuffer}
+	 * @param file the {@link ByteBuffer} to connect to.
 	 */
-	public void connect(ByteBuffer file) throws FileNotFoundException {
+	public void connect(ByteBuffer file) {
 		this.file = file;
 	}
 
 	/**
 	 * Create a new header based on the given {@link HeaderData}
 	 * @param data the {@link HeaderData} to retrieve the data from.
-	 * @throws IOException if there was an erro while writing the data to the {@link File}
 	 * @throws UnsupportedVersionError if the {@link HeaderData} contains a non-supported version
 	 */
-	public void compress(HeaderData data) throws IOException, UnsupportedVersionError {
+	public void compress(HeaderData data) throws UnsupportedVersionError {
 		if(data.version == 11) {
 			HeaderDescriptor_v11 descriptor = new HeaderDescriptor_v11();
 			file.position(0);
@@ -54,11 +49,10 @@ public class HeaderInterface {
 	}
 
 	/**
-	 * Extract the {@link HeaderData} from the linked {@link File}
+	 * Extract the {@link HeaderData} from the linked {@link ByteBuffer}
 	 * @return the extracted {@link HeaderData}
-	 * @throws IOException if there was a problem while reading the {@link File}
 	 */
-	public HeaderData extract() throws IOException {
+	public HeaderData extract() {
 		HeaderData data = new HeaderData();
 		HeaderDescriptor descriptor = new HeaderDescriptor();
 		file.position(0);
@@ -80,10 +74,8 @@ public class HeaderInterface {
 	}
 
 	/**
-	 * Close the connection with the {@link File}
-	 * @throws IOException if there was a problem while closing the {@link File}
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-	/*public void close() throws IOException {
-		file.close();
-	}*/
+	public void close() {
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/header/HeaderInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/header/HeaderInterface.java
@@ -3,7 +3,7 @@ package com.dexesttp.hkxpack.hkx.header;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.exceptions.UnsupportedVersionError;
 import com.dexesttp.hkxpack.hkx.header.internals.HeaderDescriptor;
@@ -14,15 +14,15 @@ import com.dexesttp.hkxpack.resources.ByteUtils;
  * Connects to a HKX {@link File} and allows direct access to the header contents.
  */
 public class HeaderInterface {
-	private RandomAccessFile file;
+	private ByteBuffer file;
 
 	/**
 	 * Connect to a {@link File}
 	 * @param file the file to connect to.
 	 * @throws FileNotFoundException If the given file could not be found.
 	 */
-	public void connect(File file) throws FileNotFoundException {
-		this.file = new RandomAccessFile(file, "rw");
+	public void connect(ByteBuffer file) throws FileNotFoundException {
+		this.file = file;
 	}
 
 	/**
@@ -34,19 +34,19 @@ public class HeaderInterface {
 	public void compress(HeaderData data) throws IOException, UnsupportedVersionError {
 		if(data.version == 11) {
 			HeaderDescriptor_v11 descriptor = new HeaderDescriptor_v11();
-			file.seek(0);
-			file.write(descriptor.file_id);
-			file.write(descriptor.version);
-			file.write(descriptor.extras);
-			file.write(descriptor.constants);
-			file.write(descriptor.verName);
-			file.write(descriptor.constants_2);
-			file.write(descriptor.extras_v11);
+			file.position(0);
+			file.put(descriptor.file_id);
+			file.put(descriptor.version);
+			file.put(descriptor.extras);
+			file.put(descriptor.constants);
+			file.put(descriptor.verName);
+			file.put(descriptor.constants_2);
+			file.put(descriptor.extras_v11);
 			if(data.padding_after == 16) {
-				file.write(descriptor.padding_v11);
-				file.write(descriptor.padding);	
+				file.put(descriptor.padding_v11);
+				file.put(descriptor.padding);	
 			} else {
-				file.write(new byte[] {0, 0});
+				file.put(new byte[] {0, 0});
 			}
 		} else {
 			throw new UnsupportedVersionError(data.versionName);
@@ -61,15 +61,15 @@ public class HeaderInterface {
 	public HeaderData extract() throws IOException {
 		HeaderData data = new HeaderData();
 		HeaderDescriptor descriptor = new HeaderDescriptor();
-		file.seek(0);
-		file.read(descriptor.file_id);
-		file.read(descriptor.version);
-		file.read(descriptor.extras);
-		file.read(descriptor.constants);
-		file.read(descriptor.verName);
-		file.read(descriptor.constants_2);
-		file.read(descriptor.extras_v11);
-		file.read(descriptor.padding_v11);
+		file.position(0);
+		file.get(descriptor.file_id);
+		file.get(descriptor.version);
+		file.get(descriptor.extras);
+		file.get(descriptor.constants);
+		file.get(descriptor.verName);
+		file.get(descriptor.constants_2);
+		file.get(descriptor.extras_v11);
+		file.get(descriptor.padding_v11);
 		data.version = ByteUtils.getInt(descriptor.version);
 		data.versionName = new String(descriptor.verName);
 		if(data.version == 11)
@@ -83,7 +83,7 @@ public class HeaderInterface {
 	 * Close the connection with the {@link File}
 	 * @throws IOException if there was a problem while closing the {@link File}
 	 */
-	public void close() throws IOException {
+	/*public void close() throws IOException {
 		file.close();
-	}
+	}*/
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/header/SectionInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/header/SectionInterface.java
@@ -3,7 +3,7 @@ package com.dexesttp.hkxpack.hkx.header;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import com.dexesttp.hkxpack.hkx.header.internals.SectionDescriptor;
@@ -13,7 +13,7 @@ import com.dexesttp.hkxpack.resources.ByteUtils;
  * Connects to a {@link File}, and allows easy retrieval and writing of {@link SectionData}.
  */
 public class SectionInterface {
-	private RandomAccessFile file;
+	private ByteBuffer file;
 	private HeaderData header;
 
 	/**
@@ -22,8 +22,8 @@ public class SectionInterface {
 	 * @param header the {@link HeaderData} to base the search on.
 	 * @throws FileNotFoundException if there was a problem connecting to the given {@link File}.
 	 */
-	public void connect(File file, HeaderData header) throws FileNotFoundException {
-		this.file = new RandomAccessFile(file, "rw");
+	public void connect(ByteBuffer file, HeaderData header) throws FileNotFoundException {
+		this.file = file;
 		this.header = header;
 	}
 
@@ -43,21 +43,21 @@ public class SectionInterface {
 			sectionsize = 0x40;
 		else
 			sectionsize = 0x30;
-		file.seek(0x40 + header.padding_after + sectionsize * sectionID);
+		file.position((int) (0x40 + header.padding_after + sectionsize * sectionID));
 		SectionDescriptor descriptor = new SectionDescriptor();
-		file.write(section.name.getBytes());
-		file.skipBytes(0x10 - section.name.length());
-		file.write(descriptor.constant);
-		file.write(ByteUtils.fromLong(section.offset, 4));
-		file.write(ByteUtils.fromLong(section.data1, 4));
-		file.write(ByteUtils.fromLong(section.data2, 4));
-		file.write(ByteUtils.fromLong(section.data3, 4));
-		file.write(ByteUtils.fromLong(section.data4, 4));
-		file.write(ByteUtils.fromLong(section.data5, 4));
-		file.write(ByteUtils.fromLong(section.end, 4));
+		file.put(section.name.getBytes());
+		file.position(file.position() + (0x10 - section.name.length()));
+		file.put(descriptor.constant);
+		file.put(ByteUtils.fromLong(section.offset, 4));
+		file.put(ByteUtils.fromLong(section.data1, 4));
+		file.put(ByteUtils.fromLong(section.data2, 4));
+		file.put(ByteUtils.fromLong(section.data3, 4));
+		file.put(ByteUtils.fromLong(section.data4, 4));
+		file.put(ByteUtils.fromLong(section.data5, 4));
+		file.put(ByteUtils.fromLong(section.end, 4));
 		if(header.version == 11)
 			for(int i = 0; i < 0x10; i++)
-				file.writeByte(0xFF);
+				file.put((byte) 0xFF);
 	}
 
 	/**
@@ -75,17 +75,17 @@ public class SectionInterface {
 		else
 			sectionsize = 0x30;
 		SectionData data = new SectionData();
-		file.seek(0x40 + header.padding_after + sectionsize * sectionID);
+		file.position((int) (0x40 + header.padding_after + sectionsize * sectionID));
 		SectionDescriptor descriptor = new SectionDescriptor();
-		file.read(descriptor.secName);
-		file.read(descriptor.constant);
-		file.read(descriptor.offset);
-		file.read(descriptor.data1);
-		file.read(descriptor.data2);
-		file.read(descriptor.data3);
-		file.read(descriptor.data4);
-		file.read(descriptor.data5);
-		file.read(descriptor.end);
+		file.get(descriptor.secName);
+		file.get(descriptor.constant);
+		file.get(descriptor.offset);
+		file.get(descriptor.data1);
+		file.get(descriptor.data2);
+		file.get(descriptor.data3);
+		file.get(descriptor.data4);
+		file.get(descriptor.data5);
+		file.get(descriptor.end);
 		// Convert name
 		data.name = new String(descriptor.secName, StandardCharsets.US_ASCII);
 		int last0 = data.name.indexOf(0);
@@ -105,7 +105,7 @@ public class SectionInterface {
 	 * Close the connection with the given {@link File}
 	 * @throws IOException if there was a problem while closing the {@link File}
 	 */
-	public void close() throws IOException {
+/*	public void close() throws IOException {
 		file.close();
-	}
+	}*/
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkx/header/SectionInterface.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkx/header/SectionInterface.java
@@ -1,8 +1,5 @@
 package com.dexesttp.hkxpack.hkx.header;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -10,19 +7,18 @@ import com.dexesttp.hkxpack.hkx.header.internals.SectionDescriptor;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 /**
- * Connects to a {@link File}, and allows easy retrieval and writing of {@link SectionData}.
+ * Connects to a {@link ByteBuffer}, and allows easy retrieval and writing of {@link SectionData}.
  */
 public class SectionInterface {
 	private ByteBuffer file;
 	private HeaderData header;
 
 	/**
-	 * Connect to a given {@link File}, based on the given {@link HeaderData}.
-	 * @param file the {@link File} to connect to.
+	 * Connect to a given {@link ByteBuffer}, based on the given {@link HeaderData}.
+	 * @param file the {@link ByteBuffer} to connect to.
 	 * @param header the {@link HeaderData} to base the search on.
-	 * @throws FileNotFoundException if there was a problem connecting to the given {@link File}.
 	 */
-	public void connect(ByteBuffer file, HeaderData header) throws FileNotFoundException {
+	public void connect(ByteBuffer file, HeaderData header)  {
 		this.file = file;
 		this.header = header;
 	}
@@ -35,9 +31,8 @@ public class SectionInterface {
 	 * 1 to be __types__ and 2 to be __data__
 	 * @param section The {@link SectionData} to write.
 	 * @param sectionID The Section ID to write the {@link SectionData} at.
-	 * @throws IOException if there was a problem writing to the {@link File}
 	 */
-	public void compress(SectionData section, int sectionID) throws IOException {
+	public void compress(SectionData section, int sectionID) {
 		long sectionsize;
 		if(header.version == 11)
 			sectionsize = 0x40;
@@ -66,9 +61,8 @@ public class SectionInterface {
 	 * Supported SectionIDs are 0, 1 and 2.
 	 * @param sectionID the Section ID to read.
 	 * @return the read {@link SectionData}
-	 * @throws IOException if there was a problem while reading the {@link File}.
 	 */
-	public SectionData extract(int sectionID) throws IOException {
+	public SectionData extract(int sectionID) {
 		long sectionsize;
 		if(header.version == 11)
 			sectionsize = 0x40;
@@ -102,10 +96,9 @@ public class SectionInterface {
 	}
 
 	/**
-	 * Close the connection with the given {@link File}
-	 * @throws IOException if there was a problem while closing the {@link File}
+	 * Close the connection with the given {@link ByteBuffer}
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-/*	public void close() throws IOException {
-		file.close();
-	}*/
+	public void close() {
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXObjectReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXObjectReader.java
@@ -1,11 +1,11 @@
 package com.dexesttp.hkxpack.hkxreader;
-
-import java.io.IOException;
+ 
 
 import com.dexesttp.hkxpack.data.HKXObject;
 import com.dexesttp.hkxpack.data.members.HKXFailedMember;
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.descriptor.HKXDescriptor;
+import com.dexesttp.hkxpack.descriptor.exceptions.ClassFileReadError;
 import com.dexesttp.hkxpack.descriptor.members.HKXMemberTemplate;
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 import com.dexesttp.hkxpack.hkxreader.member.HKXMemberReader;
@@ -28,7 +28,7 @@ public class HKXObjectReader {
 	 * Creates an HKXObject from a descriptor, a position and the object's name.
 	 * @param objectName the name of the object to create.
 	 * @param position the position to read the object from.
-	 * @param descriptor a descriptor of the {@link HKXObject}'s internal strucure.
+	 * @param descriptor a descriptor of the {@link HKXObject}'s internal structure.
 	 * @return the read {@link HKXObject}
 	 */
 	public HKXObject createHKXObject(String objectName, long position, HKXDescriptor descriptor) {
@@ -38,7 +38,7 @@ public class HKXObjectReader {
 			try {
 				HKXMemberReader memberReader = memberFactory.getMemberReader(memberTemplate);
 				member = memberReader.read(position);
-			} catch (IOException | InvalidPositionException e) {
+			} catch (ClassFileReadError | InvalidPositionException e) {
 				member = new HKXFailedMember(memberTemplate.name, memberTemplate.vtype, e.getClass().getName());
 				LoggerUtil.add(e);
 			}

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXReader.java
@@ -21,7 +21,7 @@ import com.dexesttp.hkxpack.hkxreader.member.HKXMemberReaderFactory;
 import com.dexesttp.hkxpack.resources.LoggerUtil;
 
 /**
- * Reads the content of a {@link File}, containing information in the hkx format, into a DOM-like {@link HKXFile}.
+ * Reads the content of a {@link File} or {@link ByteBuffer}, containing information in the hkx format, into a DOM-like {@link HKXFile}.
  */
 public class HKXReader {
 	private File hkxFile;
@@ -41,6 +41,12 @@ public class HKXReader {
 		this.enumResolver = enumResolver;
 	}
 	
+	/**
+	 * Creates a {@link HKXReader}.
+	 * @param hkxBB the {@link ByteBuffer} to read data from.
+	 * @param descriptorFactory the {@link HKXDescriptorFactory} to use to solve the {@link ByteBuffer}'s classes.
+	 * @param enumResolver the {@link HKXEnumResolver} to store enumerations into.
+	 */
 	public HKXReader(ByteBuffer hkxBB, HKXDescriptorFactory descriptorFactory, HKXEnumResolver enumResolver) {
 		this.hkxBB = hkxBB;
 		this.descriptorFactory = descriptorFactory;
@@ -48,10 +54,10 @@ public class HKXReader {
 	}
 	
 	/**
-	 * Read data from this {@link HKXReader}'s {@link File}.
+	 * Read data from this {@link HKXReader}'s {@link File} or {@link ByteBuffer}.
 	 * @return the read {@link HKXFile}
 	 * @throws IOException if there was a problem accessing the file.
-	 * @throws InvalidPositionException if there was a positionning problem while reading the file.
+	 * @throws InvalidPositionException if there was a positioning problem while reading the file.
 	 */
 	public HKXFile read() throws IOException, InvalidPositionException {
 	

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXReaderConnector.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXReaderConnector.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.classnames.ClassnamesData;
@@ -24,25 +23,22 @@ public class HKXReaderConnector {
 	public final Data2Interface data2;
 	public final Data3Interface data3;
 
-	HKXReaderConnector(ByteBuffer file) throws IOException {
+	HKXReaderConnector(ByteBuffer file) {
 		// Extract the header
 		HeaderInterface headInt = new HeaderInterface();
 		headInt.connect(file);
 		header = headInt.extract();
-		//headInt.close();
 		
 		// Extract the section interfaces
 		SectionInterface sectInt = new SectionInterface();
 		sectInt.connect(file, header);
 		classnamesHead = sectInt.extract(0);
 		dataHead = sectInt.extract(2);
-		//sectInt.close();
 		
 		// Extract the classnames
 		ClassnamesInterface cnamesInt = new ClassnamesInterface();
 		cnamesInt.connect(file, classnamesHead);
 		classnamesdata = cnamesInt.extract();
-		//cnamesInt.close();
 
 		// Connect the interfaces
 		data1 = new Data1Interface();

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXReaderConnector.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/HKXReaderConnector.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.classnames.ClassnamesData;
 import com.dexesttp.hkxpack.hkx.classnames.ClassnamesInterface;
@@ -24,25 +24,25 @@ public class HKXReaderConnector {
 	public final Data2Interface data2;
 	public final Data3Interface data3;
 
-	HKXReaderConnector(File file) throws IOException {
+	HKXReaderConnector(ByteBuffer file) throws IOException {
 		// Extract the header
 		HeaderInterface headInt = new HeaderInterface();
 		headInt.connect(file);
 		header = headInt.extract();
-		headInt.close();
+		//headInt.close();
 		
 		// Extract the section interfaces
 		SectionInterface sectInt = new SectionInterface();
 		sectInt.connect(file, header);
 		classnamesHead = sectInt.extract(0);
 		dataHead = sectInt.extract(2);
-		sectInt.close();
+		//sectInt.close();
 		
 		// Extract the classnames
 		ClassnamesInterface cnamesInt = new ClassnamesInterface();
 		cnamesInt.connect(file, classnamesHead);
 		classnamesdata = cnamesInt.extract();
-		cnamesInt.close();
+		//cnamesInt.close();
 
 		// Connect the interfaces
 		data1 = new Data1Interface();
@@ -54,5 +54,4 @@ public class HKXReaderConnector {
 		data = new DataInterface();
 		data.connect(file, dataHead);
 	}
-
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXArrayMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXArrayMemberReader.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.HKXData;
 import com.dexesttp.hkxpack.data.members.HKXArrayMember;
@@ -30,9 +30,9 @@ public abstract class HKXArrayMemberReader implements HKXMemberReader {
 	@Override
 	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
 		final int memberSize = (int) MemberSizeResolver.getSize(HKXType.TYPE_ARRAY);
-		RandomAccessFile file = connector.data.setup(classOffset + memberOffset);
+		ByteBuffer file = connector.data.setup(classOffset + memberOffset);
 		byte[] b = new byte[memberSize];
-		file.read(b);
+		file.get(b);
 		HKXArrayMember result = new HKXArrayMember(name, HKXType.TYPE_ARRAY, subtype);
 		int arrSize = getSizeComponent(b);
 		if(arrSize > 0) {

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXArrayMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXArrayMemberReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.HKXData;
@@ -31,7 +30,7 @@ public class HKXArrayMemberReader implements HKXMemberReader {
 	}
 
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		final int memberSize = (int) MemberSizeResolver.getSize(HKXType.TYPE_ARRAY);
 		ByteBuffer file = connector.data.setup(classOffset + memberOffset);
 		byte[] b = new byte[memberSize];

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXDirectArrayMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXDirectArrayMemberReader.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.HKXData;
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -21,8 +21,8 @@ class HKXDirectArrayMemberReader extends HKXArrayMemberReader {
 	protected HKXData getContents(long arrayStart, int position) throws IOException, InvalidPositionException {
 		final int contentSize = (int) MemberSizeResolver.getSize(subtype);
 		byte[] b = new byte[contentSize];
-		RandomAccessFile file = connector.data.setup(arrayStart + position * contentSize);
-		file.read(b);
+		ByteBuffer file = connector.data.setup(arrayStart + position * contentSize);
+		file.get(b);
 		HKXMember data = MemberDataResolver.getMember(name, subtype, b);
 		return data;
 	}

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXDirectMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXDirectMemberReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -25,7 +24,7 @@ class HKXDirectMemberReader implements HKXMemberReader {
 	}
 
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		final int memberSize = (int) MemberSizeResolver.getSize(vtype);
 		ByteBuffer file = connector.data.setup(classOffset + memberOffset);
 		byte[] b = new byte[memberSize];

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXDirectMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXDirectMemberReader.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.descriptor.enums.HKXType;
@@ -27,9 +27,9 @@ class HKXDirectMemberReader implements HKXMemberReader {
 	@Override
 	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
 		final int memberSize = (int) MemberSizeResolver.getSize(vtype);
-		RandomAccessFile file = connector.data.setup(classOffset + memberOffset);
+		ByteBuffer file = connector.data.setup(classOffset + memberOffset);
 		byte[] b = new byte[memberSize];
-		file.read(b);
+		file.get(b);
 		HKXMember result = MemberDataResolver.getMember(name, vtype, b);
 		return result;
 	}

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXEnumMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXEnumMemberReader.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXEnumMember;
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -34,9 +34,9 @@ public class HKXEnumMemberReader implements HKXMemberReader {
 	@Override
 	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
 		final int memberSize = (int) MemberSizeResolver.getSize(vsubtype);
-		RandomAccessFile file = connector.data.setup(classOffset + memberOffset);
+		ByteBuffer file = connector.data.setup(classOffset + memberOffset);
 		byte[] b = new byte[memberSize];
-		file.read(b);
+		file.get(b);
 		int contents = ByteUtils.getInt(b);
 		HKXEnumMember result = new HKXEnumMember(name, vtype, vsubtype, etype);
 		result.set(enumResolver.resolve(etype, contents));

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXEnumMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXEnumMemberReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXEnumMember;
@@ -32,7 +31,7 @@ public class HKXEnumMemberReader implements HKXMemberReader {
 	}
 
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		final int memberSize = (int) MemberSizeResolver.getSize(vsubtype);
 		ByteBuffer file = connector.data.setup(classOffset + memberOffset);
 		byte[] b = new byte[memberSize];

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXMemberReader.java
@@ -1,10 +1,8 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 
 public interface HKXMemberReader {
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException;
+	public HKXMember read(long classOffset) throws InvalidPositionException;
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXObjectMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXObjectMemberReader.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.HKXObject;
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.descriptor.HKXDescriptor;
@@ -22,7 +20,7 @@ class HKXObjectMemberReader implements HKXMemberReader {
 	}
 
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		HKXObject res = objectReader.createHKXObject(name, classOffset + offset, descriptor);
 		return res;
 	}

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXPointerMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXPointerMemberReader.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.data.members.HKXPointerMember;
 import com.dexesttp.hkxpack.descriptor.enums.HKXType;
@@ -26,7 +24,7 @@ class HKXPointerMemberReader implements HKXMemberReader {
 	}
 
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		DataExternal data = connector.data2.readNext();
 		String target = "null";
 		if(data.from == memberOffset + classOffset) {

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXRelArrayMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXRelArrayMemberReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXArrayMember;
@@ -27,7 +26,7 @@ public class HKXRelArrayMemberReader implements HKXMemberReader {
 	}
 	
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		ByteBuffer file = connector.data.setup(classOffset + offset);
 		byte[] bSize = new byte[2];
 		byte[] bOff = new byte[2];

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXStringArrayMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXStringArrayMemberReader.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.HKXData;
 import com.dexesttp.hkxpack.data.members.HKXStringMember;
@@ -23,7 +23,7 @@ class HKXStringArrayMemberReader extends HKXArrayMemberReader {
 		DataInternal data = connector.data1.readNext();
 		String contents = "";
 		if(data.from == descriptorPosition) {
-			RandomAccessFile file = connector.data.setup(data.to);
+			ByteBuffer file = connector.data.setup(data.to);
 			contents = ByteUtils.readString(file);
 		} else {
 			connector.data1.backtrack();

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXStringMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXStringMemberReader.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.data.members.HKXStringMember;
@@ -30,7 +30,7 @@ class HKXStringMemberReader implements HKXMemberReader {
 		try {
 			DataInternal data = connector.data1.readNext();
 			if(data.from == memberOffset + classOffset) {
-				RandomAccessFile file = connector.data.setup(data.to);
+				ByteBuffer file = connector.data.setup(data.to);
 				contents = ByteUtils.readString(file);
 			} else {
 				connector.data1.backtrack();

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXStringMemberReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/HKXStringMemberReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -25,7 +24,7 @@ class HKXStringMemberReader implements HKXMemberReader {
 	}
 
 	@Override
-	public HKXMember read(long classOffset) throws IOException, InvalidPositionException {
+	public HKXMember read(long classOffset) throws InvalidPositionException {
 		String contents = "";
 		try {
 			DataInternal data = connector.data1.readNext();

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXArrayContentsReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXArrayContentsReader.java
@@ -1,10 +1,8 @@
 package com.dexesttp.hkxpack.hkxreader.member.arrays;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.HKXData;
 import com.dexesttp.hkxpack.hkx.exceptions.InvalidPositionException;
 
 public interface HKXArrayContentsReader {
-	public HKXData getContents(long arrayStart, int position) throws IOException, InvalidPositionException;
+	public HKXData getContents(long arrayStart, int position) throws InvalidPositionException;
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXDirectArrayContentsReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXDirectArrayContentsReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member.arrays;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.HKXData;
@@ -21,7 +20,7 @@ class HKXDirectArrayContentsReader implements HKXArrayContentsReader {
 	}
 
 	@Override
-	public HKXData getContents(long arrayStart, int position) throws IOException, InvalidPositionException {
+	public HKXData getContents(long arrayStart, int position) throws InvalidPositionException {
 		final int contentSize = (int) MemberSizeResolver.getSize(contentType);
 		byte[] b = new byte[contentSize];
 		ByteBuffer file = connector.data.setup(arrayStart + position * contentSize);

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXObjectArrayContentsReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXObjectArrayContentsReader.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member.arrays;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.HKXData;
 import com.dexesttp.hkxpack.data.HKXObject;
 import com.dexesttp.hkxpack.descriptor.HKXDescriptor;
@@ -23,7 +21,7 @@ class HKXObjectArrayContentsReader implements HKXArrayContentsReader {
 	}
 
 	@Override
-	public HKXData getContents(long arrayStart, int position) throws IOException, InvalidPositionException {
+	public HKXData getContents(long arrayStart, int position) throws InvalidPositionException {
 		long contentsPos = arrayStart + position * contentSize;
 		HKXObject data = reader.createHKXObject("", contentsPos, descriptor);
 		return data;

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXPointerArrayContentsReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXPointerArrayContentsReader.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member.arrays;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.HKXData;
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.data.members.HKXPointerMember;
@@ -21,7 +19,7 @@ public class HKXPointerArrayContentsReader implements HKXArrayContentsReader {
 	}
 
 	@Override
-	public HKXData getContents(long arrayStart, int position) throws IOException, InvalidPositionException {
+	public HKXData getContents(long arrayStart, int position) throws InvalidPositionException {
 		long contentsPosition = arrayStart + position * 0x08;
 		DataExternal data = connector.data2.readNext();
 		String target = "null";

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXStringArrayContentsReader.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxreader/member/arrays/HKXStringArrayContentsReader.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxreader.member.arrays;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.HKXData;
@@ -21,7 +20,7 @@ class HKXStringArrayContentsReader implements HKXArrayContentsReader {
 	}
 
 	@Override
-	public HKXData getContents(long arrayStart, int position) throws IOException, InvalidPositionException {
+	public HKXData getContents(long arrayStart, int position) throws InvalidPositionException {
 		long descriptorPosition = arrayStart + position * 0x08;
 		DataInternal data = connector.data1.readNext();
 		String contents = "";

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXDataHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXDataHandler.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +29,8 @@ class HKXDataHandler {
 	private final List<DataExternal> data3queue;
 
 	/**
-	 * Create a {@link HKXDataHandler} assocaited with the given output {@link File} as well as the given {@link HKXEnumResolver}.
-	 * @param outFile the {@link File} to write data to.
+	 * Create a {@link HKXDataHandler} associated with the given output {@link ByteBuffer} as well as the given {@link HKXEnumResolver}.
+	 * @param outFile the {@link ByteBuffer} to write data to.
 	 * @param classnamesData the {@link ClassnamesData}.
 	 * @param enumResolver the {@link HKXEnumResolver} to resolve enums with.
 	 */
@@ -46,14 +44,13 @@ class HKXDataHandler {
 	}
 
 	/**
-	 * Fill this {@link HKXDataHandler}'s {@link File} section 'data' with the given {@link HKXFile}'s contents.
+	 * Fill this {@link HKXDataHandler}'s {@link ByteBuffer} section 'data' with the given {@link HKXFile}'s contents.
 	 * @param data the {@link SectionData} describing at least the data offset.
 	 * @param file the {@link HKXFile} to write data from.
 	 * @param resolver the PointerResolver to resolve objects with.
 	 * @return the position of the byte just after the end of the Data section
-	 * @throws IOException if there was a problem writing to this {@link HKXDataHandler}'s {@link File}.
 	 */
-	long fillFile(SectionData data, HKXFile file, PointerResolver resolver) throws IOException {
+	long fillFile(SectionData data, HKXFile file, PointerResolver resolver) {
 		long currentPos = data.offset;
 		HKXObjectHandler objectHandler = new HKXObjectHandler(outFile, cnameData, data, enumResolver, data1queue, data2queue, data3queue, resolver);
 		for(HKXObject object : file.content()) {
@@ -64,11 +61,10 @@ class HKXDataHandler {
 	}
 
 	/**
-	 * Fill the file with the intended Data pointers, and store the offsets in the given {@link SectionData}.
+	 * Fill the file {@link ByteBuffer} with the intended Data pointers, and store the offsets in the given {@link SectionData}.
 	 * @param data the section data to store the offsets into.
-	 * @throws IOException if there was a problem writing data to the file.
 	 */
-	void fillPointers(SectionData data, PointerResolver resolver) throws IOException {
+	void fillPointers(SectionData data, PointerResolver resolver) {
 		HKXPointersHandler handler = new HKXPointersHandler(outFile, data);
 		List<DataExternal> data2resolved = new ArrayList<>();
 		for(DataInternal internal : data1queue) {

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXDataHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXDataHandler.java
@@ -2,6 +2,7 @@ package com.dexesttp.hkxpack.hkxwriter;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +23,7 @@ import com.dexesttp.hkxpack.hkxwriter.utils.PointerResolver;
  * This uses {@link HKXPointersHandler} and {@link HKXObjectHandler} as its main components.
  */
 class HKXDataHandler {
-	private final File outFile;
+	private final ByteBuffer outFile;
 	private final ClassnamesData cnameData;
 	private final HKXEnumResolver enumResolver;
 	private final List<DataInternal> data1queue;
@@ -35,7 +36,7 @@ class HKXDataHandler {
 	 * @param classnamesData the {@link ClassnamesData}.
 	 * @param enumResolver the {@link HKXEnumResolver} to resolve enums with.
 	 */
-	HKXDataHandler(File outFile, ClassnamesData classnamesData, HKXEnumResolver enumResolver) {
+	HKXDataHandler(ByteBuffer outFile, ClassnamesData classnamesData, HKXEnumResolver enumResolver) {
 		this.outFile = outFile;
 		this.cnameData = classnamesData;
 		this.enumResolver = enumResolver;

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXObjectHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXObjectHandler.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +31,7 @@ public class HKXObjectHandler {
 	public HKXObjectHandler(ByteBuffer outFile, ClassnamesData classnamesData, SectionData dataSection,
 			HKXEnumResolver enumResolver, List<DataInternal> data1List,
 			List<PointerObject> data2List, List<DataExternal> data3List,
-			PointerResolver resolver)
-					throws FileNotFoundException {
+			PointerResolver resolver) {
 		this.outFile = outFile;
 		this.enumResolver = enumResolver;
 		this.cnameData = classnamesData;
@@ -45,7 +42,7 @@ public class HKXObjectHandler {
 		this.resolver = resolver;
 	}
 
-	public long handle(HKXObject object, long currentPos) throws IOException {
+	public long handle(HKXObject object, long currentPos) {
 		// Add the object into data3 and the resolver
 		DataExternal classEntry = new DataExternal();
 		classEntry.from = currentPos - section.offset;
@@ -66,7 +63,6 @@ public class HKXObjectHandler {
 			HKXMemberCallback callback = memberCallbacks.remove(0);
 			currentPos += callback.process(memberCallbacks, currentPos);
 		}
-		//memberHandlerFactory.close();
 		return currentPos;
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXObjectHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXObjectHandler.java
@@ -1,8 +1,8 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,13 +24,13 @@ public class HKXObjectHandler {
 	private final ClassnamesData cnameData;
 	private final SectionData section;
 	private final PointerResolver resolver;
-	private final File outFile;
+	private final ByteBuffer outFile;
 	private final HKXEnumResolver enumResolver;
 	private final List<DataInternal> data1List;
 	private final List<PointerObject> data2List;
 	private final List<DataExternal> data3List;
 
-	public HKXObjectHandler(File outFile, ClassnamesData classnamesData, SectionData dataSection,
+	public HKXObjectHandler(ByteBuffer outFile, ClassnamesData classnamesData, SectionData dataSection,
 			HKXEnumResolver enumResolver, List<DataInternal> data1List,
 			List<PointerObject> data2List, List<DataExternal> data3List,
 			PointerResolver resolver)
@@ -66,7 +66,7 @@ public class HKXObjectHandler {
 			HKXMemberCallback callback = memberCallbacks.remove(0);
 			currentPos += callback.process(memberCallbacks, currentPos);
 		}
-		memberHandlerFactory.close();
+		//memberHandlerFactory.close();
 		return currentPos;
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXPointersHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXPointersHandler.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -13,7 +11,7 @@ import com.dexesttp.hkxpack.hkx.data.DataInternal;
 import com.dexesttp.hkxpack.hkx.header.SectionData;
 
 /**
- * Write pointers (stored internally as a list of {@link DataInternal} and {@link DataExternal}) into the given file, at the described position.
+ * Write pointers (stored internally as a list of {@link DataInternal} and {@link DataExternal}) into the given file {@link ByteBuffer}, at the described position.
  */
 class HKXPointersHandler {
 	private ByteBuffer outFile;
@@ -21,7 +19,7 @@ class HKXPointersHandler {
 
 	/**
 	 * Create a {@link HKXPointersHandler}.
-	 * @param outFile the {@link File} to write data to.
+	 * @param outFile the {@link ByteBuffer} to write data to.
 	 * @param data the {@link SectionData} describing at least the wanted offset and data1 position.
 	 */
 	HKXPointersHandler(ByteBuffer outFile, SectionData data) {
@@ -30,13 +28,12 @@ class HKXPointersHandler {
 	}
 
 	/**
-	 * Write the pointers list to this handler's {@link File}.
+	 * Write the pointers list to this handler's {@link ByteBuffer}.
 	 * @param data1List the list of {@link DataInternal} to store into data1
 	 * @param data2List the list of {@link DataExternal} to store into data2
 	 * @param data3List the list of {@link DataExternal} to store into data3
-	 * @throws IOException if there was a problem writing data to the file.
 	 */
-	void write(List<DataInternal> data1List, List<DataExternal> data2List, List<DataExternal> data3List) throws IOException {
+	void write(List<DataInternal> data1List, List<DataExternal> data2List, List<DataExternal> data3List) {
 		// handle data1
 		Data1Interface connector1 = new Data1Interface();
 		connector1.connect(outFile, data);
@@ -45,7 +42,6 @@ class HKXPointersHandler {
 		for(DataInternal internal : data1List) {
 			endPos = connector1.write(i++, internal);
 		}
-		//connector1.close();
 		endPos = fillBytes(endPos + data.offset) - data.offset;
 		data.data2 = endPos;
 		
@@ -56,7 +52,6 @@ class HKXPointersHandler {
 		for(DataExternal pointer : data2List) {
 			endPos = connector2.write(j++, pointer);
 		}
-		//connector2.close();
 		endPos = fillBytes(endPos + data.offset) - data.offset;
 		data.data3 = endPos;
 		
@@ -67,7 +62,6 @@ class HKXPointersHandler {
 		for(DataExternal classLink : data3List) {
 			endPos = connector3.write(k++, classLink);
 		}
-		//connector3.close();
 		endPos = fillBytes(endPos + data.offset) - data.offset;
 		
 		// Fill the section header.
@@ -76,16 +70,14 @@ class HKXPointersHandler {
 		data.end = endPos;
 	}
 
-	private long fillBytes(long endPos) throws IOException {
+	private long fillBytes(long endPos) {
 		if(endPos % 0x10 == 0)
 			return endPos;
 		long newEndPos = (1 + endPos / 0x10) * 0x10;
-		//RandomAccessFile file = new RandomAccessFile(outFile, "rw");
 		outFile.position((int) endPos);
 		for(; endPos < newEndPos; endPos++ ) {
 			outFile.put((byte) 0xFF);
 		}
-		//outFile.close();
 		return newEndPos;
 	}
 

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXPointersHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXPointersHandler.java
@@ -2,7 +2,7 @@ package com.dexesttp.hkxpack.hkxwriter;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.dexesttp.hkxpack.hkx.data.Data1Interface;
@@ -16,7 +16,7 @@ import com.dexesttp.hkxpack.hkx.header.SectionData;
  * Write pointers (stored internally as a list of {@link DataInternal} and {@link DataExternal}) into the given file, at the described position.
  */
 class HKXPointersHandler {
-	private File outFile;
+	private ByteBuffer outFile;
 	private SectionData data;
 
 	/**
@@ -24,7 +24,7 @@ class HKXPointersHandler {
 	 * @param outFile the {@link File} to write data to.
 	 * @param data the {@link SectionData} describing at least the wanted offset and data1 position.
 	 */
-	HKXPointersHandler(File outFile, SectionData data) {
+	HKXPointersHandler(ByteBuffer outFile, SectionData data) {
 		this.outFile = outFile;
 		this.data = data;
 	}
@@ -45,7 +45,7 @@ class HKXPointersHandler {
 		for(DataInternal internal : data1List) {
 			endPos = connector1.write(i++, internal);
 		}
-		connector1.close();
+		//connector1.close();
 		endPos = fillBytes(endPos + data.offset) - data.offset;
 		data.data2 = endPos;
 		
@@ -56,7 +56,7 @@ class HKXPointersHandler {
 		for(DataExternal pointer : data2List) {
 			endPos = connector2.write(j++, pointer);
 		}
-		connector2.close();
+		//connector2.close();
 		endPos = fillBytes(endPos + data.offset) - data.offset;
 		data.data3 = endPos;
 		
@@ -67,7 +67,7 @@ class HKXPointersHandler {
 		for(DataExternal classLink : data3List) {
 			endPos = connector3.write(k++, classLink);
 		}
-		connector3.close();
+		//connector3.close();
 		endPos = fillBytes(endPos + data.offset) - data.offset;
 		
 		// Fill the section header.
@@ -80,12 +80,12 @@ class HKXPointersHandler {
 		if(endPos % 0x10 == 0)
 			return endPos;
 		long newEndPos = (1 + endPos / 0x10) * 0x10;
-		RandomAccessFile file = new RandomAccessFile(outFile, "rw");
-		file.seek(endPos);
+		//RandomAccessFile file = new RandomAccessFile(outFile, "rw");
+		outFile.position((int) endPos);
 		for(; endPos < newEndPos; endPos++ ) {
-			file.writeByte(0xFF);
+			outFile.put((byte) 0xFF);
 		}
-		file.close();
+		//outFile.close();
 		return newEndPos;
 	}
 

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXWriter.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXWriter.java
@@ -1,7 +1,11 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel.MapMode;
 
 import com.dexesttp.hkxpack.data.HKXFile;
 import com.dexesttp.hkxpack.descriptor.HKXEnumResolver;
@@ -18,64 +22,94 @@ import com.dexesttp.hkxpack.hkxwriter.utils.PointerResolver;
 /**
  * Handles writing a {@link HKXFile} into a {@link File}, using the binary hkx notation.
  */
-public class HKXWriter {
+public class HKXWriter
+{
 	private HKXEnumResolver enumResolver;
 	private File outputFile;
+	private ByteBuffer outputBB;
 
 	/**
 	 * Creates a {@link HKXWriter}.
 	 * @param outputFile the {@link File} to output data into.
 	 * @param enumResolver the {@link HKXEnumResolver} to use.
 	 */
-	public HKXWriter(File outputFile, HKXEnumResolver enumResolver) {
+	public HKXWriter(File outputFile, HKXEnumResolver enumResolver)
+	{
 		this.enumResolver = enumResolver;
 		this.outputFile = outputFile;
 	}
-	
+
+	public HKXWriter(HKXEnumResolver enumResolver)
+	{
+		this.enumResolver = enumResolver;
+	}
+
+	public ByteBuffer getByteBuffer()
+	{
+		return outputBB;
+	}
+
 	/**
 	 * Writes a {@link HKXFile}'s data inot this {@link HKXReader}'s {@link File}.
 	 * @param file the {@link HKXFile} to take data from.
 	 * @throws IOException 
 	 * @throws UnsupportedVersionError 
 	 */
-	public void write(HKXFile file) throws IOException, UnsupportedVersionError {
+	public void write(HKXFile file) throws IOException, UnsupportedVersionError
+	{
+
+		outputBB = ByteBuffer.allocateDirect(10000000);//10 meg max should be fine, it'll only use what it needs
+
 		// Connect to the file.
-		HKXWriterConnector connector = new HKXWriterConnector(outputFile);
+		HKXWriterConnector connector = new HKXWriterConnector(outputBB);
 		connector.clean();
-		
+
 		// Create the header.
 		HeaderData header = new HKXHeaderFactory().create(file);
-		
+
 		// Create the file's section data.
 		HKXSectionHandler sectionHandler = new HKXSectionHandler(header);
 		SectionData classnames = new SectionData();
 		SectionData types = new SectionData();
 		SectionData data = new SectionData();
 		sectionHandler.init(HKXSectionHandler.CLASSNAME, classnames);
-		
+
 		// Create the ClassNames data.
 		HKXClassnamesHandler cnameHandler = new HKXClassnamesHandler();
 		ClassnamesData cnameData = cnameHandler.getClassnames(file);
-		
+
 		// Write ClassNames data to the file.
 		long classnamesEnd = connector.writeClassnames(classnames, cnameData);
 		sectionHandler.fillCName(classnames, classnamesEnd);
 		connector.writeHeader(header);
 		connector.writeSection(header, HKXSectionHandler.CLASSNAME, classnames);
-		
+
 		// Update things to prepare for Data writing.
 		sectionHandler.init(HKXSectionHandler.TYPES, types);
 		connector.writeSection(header, HKXSectionHandler.TYPES, types);
 		sectionHandler.init(HKXSectionHandler.DATA, data);
-		
+
 		// Write data in the file and store data1/data2/data3 values.
 		PointerResolver resolver = new PointerResolver();
-		HKXDataHandler dataHandler = new HKXDataHandler(outputFile, cnameData, enumResolver);
+		HKXDataHandler dataHandler = new HKXDataHandler(outputBB, cnameData, enumResolver);
 		long endData = dataHandler.fillFile(data, file, resolver) - data.offset;
-		data.data1 = endData%0x10 == 0 ? endData : (1 + endData / 0x10) * 0x10;
+		data.data1 = endData % 0x10 == 0 ? endData : (1 + endData / 0x10) * 0x10;
 		dataHandler.fillPointers(data, resolver);
-		
+
 		// Write the data section to the file.
 		connector.writeSection(header, HKXSectionHandler.DATA, data);
+
+		if (outputFile != null)
+		{
+			try (RandomAccessFile out = new RandomAccessFile(outputFile, "rw"))
+			{
+				outputBB.flip();
+				byte[] bytes = new byte[outputBB.limit()];
+				outputBB.get(bytes);
+				out.write(bytes);
+				out.close();
+			}
+		}
+
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXWriterConnector.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXWriterConnector.java
@@ -1,8 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.classnames.ClassnamesData;
 import com.dexesttp.hkxpack.hkx.classnames.ClassnamesInterface;
@@ -17,13 +16,13 @@ import com.dexesttp.hkxpack.hkxreader.HKXReaderConnector;
  * Handles all connections to the {@link File} for {@link HeaderData} and {@link SectionData} objects.
  */
 class HKXWriterConnector {
-	private File file;
+	private ByteBuffer file;
 
 	/**
 	 * Creates a {@link HKXWriterConnector} linked to the given {@link File}.
 	 * @param outputFile the {@link File} to link this connector to.
 	 */
-	HKXWriterConnector(File outputFile) {
+	HKXWriterConnector(ByteBuffer outputFile) {
 		this.file = outputFile;
 	}
 	
@@ -32,8 +31,8 @@ class HKXWriterConnector {
 	 * @throws IOException if there was a problem cleaning the file.
 	 */
 	void clean() throws IOException {
-		PrintWriter writer = new PrintWriter(file);
-		writer.close();
+		//PrintWriter writer = new PrintWriter(file);
+		//writer.close();
 	}
 
 	/**
@@ -46,7 +45,7 @@ class HKXWriterConnector {
 		HeaderInterface headerConnector = new HeaderInterface();
 		headerConnector.connect(file);
 		headerConnector.compress(data);
-		headerConnector.close();
+		//headerConnector.close();
 	}
 
 	/**
@@ -60,7 +59,7 @@ class HKXWriterConnector {
 		SectionInterface sectionConnector = new SectionInterface();
 		sectionConnector.connect(file, header);
 		sectionConnector.compress(section, sectionID);
-		sectionConnector.close();
+		//sectionConnector.close();
 	}
 
 	/**
@@ -74,7 +73,7 @@ class HKXWriterConnector {
 		ClassnamesInterface classnamesConnector = new ClassnamesInterface();
 		classnamesConnector.connect(file, classnames);
 		long cnameEnd = classnamesConnector.compress(data);
-		classnamesConnector.close();
+		//classnamesConnector.close();
 		return cnameEnd;
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXWriterConnector.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/HKXWriterConnector.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.hkx.classnames.ClassnamesData;
@@ -13,14 +12,14 @@ import com.dexesttp.hkxpack.hkx.header.SectionInterface;
 import com.dexesttp.hkxpack.hkxreader.HKXReaderConnector;
 
 /**
- * Handles all connections to the {@link File} for {@link HeaderData} and {@link SectionData} objects.
+ * Handles all connections to the {@link ByteBuffer} for {@link HeaderData} and {@link SectionData} objects.
  */
 class HKXWriterConnector {
 	private ByteBuffer file;
 
 	/**
-	 * Creates a {@link HKXWriterConnector} linked to the given {@link File}.
-	 * @param outputFile the {@link File} to link this connector to.
+	 * Creates a {@link HKXWriterConnector} linked to the given {@link ByteBuffer}.
+	 * @param outputFile the {@link ByteBuffer} to link this connector to.
 	 */
 	HKXWriterConnector(ByteBuffer outputFile) {
 		this.file = outputFile;
@@ -28,52 +27,44 @@ class HKXWriterConnector {
 	
 	/**
 	 * Cleans the file.
-	 * @throws IOException if there was a problem cleaning the file.
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-	void clean() throws IOException {
-		//PrintWriter writer = new PrintWriter(file);
-		//writer.close();
+	void clean() {
 	}
 
 	/**
-	 * Writes the given {@link HeaderData} to this {@link HKXWriterConnector}'s {@link File}
+	 * Writes the given {@link HeaderData} to this {@link HKXWriterConnector}'s {@link ByteBuffer}
 	 * @param data the {@link HeaderData} to write.
-	 * @throws IOException if there was an error while writing to the {@link File}.
 	 * @throws UnsupportedVersionError if the given {@link HeaderData} have an unsupported version.
 	 */
-	void writeHeader(HeaderData data) throws IOException, UnsupportedVersionError {
+	void writeHeader(HeaderData data) throws  UnsupportedVersionError {
 		HeaderInterface headerConnector = new HeaderInterface();
 		headerConnector.connect(file);
 		headerConnector.compress(data);
-		//headerConnector.close();
 	}
 
 	/**
-	 * Writes the given {@link SectionData} as the sectionID's section header of this {@link HKXWriterConnector}'s {@link File}.
+	 * Writes the given {@link SectionData} as the sectionID's section header of this {@link HKXWriterConnector}'s {@link ByteBuffer}.
 	 * @param header the {@link HeaderData} to seek offsets from.
 	 * @param sectionID the section position to write.
 	 * @param section the {@link SectionData} to write to the file.
-	 * @throws IOException if there was a problem while writing to the {@link File}.
 	 */
-	void writeSection(HeaderData header, int sectionID, SectionData section) throws IOException {
+	void writeSection(HeaderData header, int sectionID, SectionData section) {
 		SectionInterface sectionConnector = new SectionInterface();
 		sectionConnector.connect(file, header);
 		sectionConnector.compress(section, sectionID);
-		//sectionConnector.close();
 	}
 
 	/**
-	 * Writes the given {@link ClassnamesData} object to this {@link HKXReaderConnector}'s {@link File}.
+	 * Writes the given {@link ClassnamesData} object to this {@link HKXReaderConnector}'s {@link ByteBuffer}.
 	 * @param classnames the {@link SectionData} related to the {@link ClassnamesData}. It must be initialized at least for its offset.
 	 * @param data the {@link ClassnamesData} to write.
 	 * @return the position of the byte just after the end of the ClassnamesData section.
-	 * @throws IOException if there was a problem while writing to the {@link File}.
 	 */
-	public long writeClassnames(SectionData classnames, ClassnamesData data) throws IOException {
+	public long writeClassnames(SectionData classnames, ClassnamesData data) {
 		ClassnamesInterface classnamesConnector = new ClassnamesInterface();
 		classnamesConnector.connect(file, classnames);
 		long cnameEnd = classnamesConnector.compress(data);
-		//classnamesConnector.close();
 		return cnameEnd;
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXArrayMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXArrayMemberHandler.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,12 +18,12 @@ import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXStringArrayMemberCallb
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 public class HKXArrayMemberHandler implements HKXMemberHandler {
-	private final RandomAccessFile outFile;
+	private final ByteBuffer outFile;
 	private final long offset;
 	private final List<DataInternal> data1;
 	private final HKXMemberHandlerFactory memberHandlerFactory;
 
-	public HKXArrayMemberHandler(RandomAccessFile outFile, long offset,
+	public HKXArrayMemberHandler(ByteBuffer outFile, long offset,
 			List<DataInternal> data1List, HKXMemberHandlerFactory hkxMemberHandlerFactory) {
 		this.outFile = outFile;
 		this.offset = offset;
@@ -41,8 +41,8 @@ public class HKXArrayMemberHandler implements HKXMemberHandler {
 				sizeVals[0], sizeVals[1], sizeVals[2], sizeVals[3],
 				sizeVals[0], sizeVals[1], sizeVals[2], (byte) 0x80
 		};
-		outFile.seek(currentPos + offset);
-		outFile.write(arrayData);
+		outFile.position((int) (currentPos + offset));
+		outFile.put(arrayData);
 		if(size == 0)
 			return (memberCallbacks, position) -> { return 0; };
 		

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXDirectMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXDirectMemberHandler.java
@@ -1,17 +1,17 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.hkx.types.MemberDataResolver;
 import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXMemberCallback;
 
 public class HKXDirectMemberHandler implements HKXMemberHandler {
-	private final RandomAccessFile outFile;
+	private final ByteBuffer outFile;
 	private final long memberOffset;
 
-	HKXDirectMemberHandler(RandomAccessFile outFile, long memberOffset) {
+	HKXDirectMemberHandler(ByteBuffer outFile, long memberOffset) {
 		this.outFile = outFile;
 		this.memberOffset = memberOffset;
 	}
@@ -19,8 +19,8 @@ public class HKXDirectMemberHandler implements HKXMemberHandler {
 	@Override
 	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
 		byte[] value = MemberDataResolver.fromMember(member);
-		outFile.seek(currentPos + memberOffset);
-		outFile.write(value);
+		outFile.position((int) (currentPos + memberOffset));
+		outFile.put(value);
 		return (memberCallbacks, position) -> { return 0; };
 	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXDirectMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXDirectMemberHandler.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -17,7 +16,7 @@ public class HKXDirectMemberHandler implements HKXMemberHandler {
 	}
 
 	@Override
-	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
+	public HKXMemberCallback write(HKXMember member, long currentPos) {
 		byte[] value = MemberDataResolver.fromMember(member);
 		outFile.position((int) (currentPos + memberOffset));
 		outFile.put(value);

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXEnumMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXEnumMemberHandler.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXEnumMember;
@@ -22,7 +21,7 @@ public class HKXEnumMemberHandler implements HKXMemberHandler {
 	}
 
 	@Override
-	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
+	public HKXMemberCallback write(HKXMember member, long currentPos) {
 		HKXEnumMember enumMember = (HKXEnumMember) member;
 		if(!enumMember.getEnumName().isEmpty()) {
 			outFile.position((int) (currentPos + offset));

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXEnumMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXEnumMemberHandler.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 
 import com.dexesttp.hkxpack.data.members.HKXEnumMember;
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -11,11 +11,11 @@ import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXMemberCallback;
 import com.dexesttp.hkxpack.resources.ByteUtils;
 
 public class HKXEnumMemberHandler implements HKXMemberHandler {
-	private final RandomAccessFile outFile;
+	private final ByteBuffer outFile;
 	private final long offset;
 	private final HKXEnumResolver enumResolver;
 
-	public HKXEnumMemberHandler(RandomAccessFile outFile, long offset, HKXEnumResolver enumResolver) {
+	public HKXEnumMemberHandler(ByteBuffer outFile, long offset, HKXEnumResolver enumResolver) {
 		this.outFile = outFile;
 		this.offset = offset;
 		this.enumResolver = enumResolver;
@@ -25,10 +25,10 @@ public class HKXEnumMemberHandler implements HKXMemberHandler {
 	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
 		HKXEnumMember enumMember = (HKXEnumMember) member;
 		if(!enumMember.getEnumName().isEmpty()) {
-			outFile.seek(currentPos + offset);
+			outFile.position((int) (currentPos + offset));
 			long enumVal = enumResolver.resolve(enumMember.getEnumName(), enumMember.get());
 			byte[] res = ByteUtils.fromLong(enumVal, (int) MemberSizeResolver.getSize(enumMember.getSubtype()));
-			outFile.write(res);
+			outFile.put(res);
 		}
 		return (memberCallbacks, position) -> { return 0; };
 	}

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXInternalObjectHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXInternalObjectHandler.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import com.dexesttp.hkxpack.data.HKXObject;
@@ -10,15 +8,13 @@ import com.dexesttp.hkxpack.descriptor.members.HKXMemberTemplate;
 import com.dexesttp.hkxpack.hkx.types.ObjectSizeResolver;
 import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXMemberCallback;
 
-/**
- * Handles writing a {@link HKXObject}'s contents into a {@link File}.
- */
+ 
 public class HKXInternalObjectHandler {
 	private final HKXMemberHandlerFactory memberHandlerFactory;
 	private List<HKXMemberCallback> memberCallbacks;
 
 	/**
-	 * Creates a handler to write an internal object to a {@link File}.
+	 * Associates a handler to a series of callbacks for writing to
 	 * @param factory the {@link HKXMemberHandlerFactory} to use while solving the {@link HKXObject}'s members.
 	 * @param memberCallbacks the list of {@link HKXMemberCallback} to add callbacks into.
 	 */
@@ -27,7 +23,7 @@ public class HKXInternalObjectHandler {
 		this.memberCallbacks = memberCallbacks;
 	}
 	
-	public long write(HKXMember objectAsMember, long currentPos) throws IOException {
+	public long write(HKXMember objectAsMember, long currentPos) {
 		HKXObject object = (HKXObject) objectAsMember;
 		// Prepare the member handlers, and fill the raw structure.
 		List<HKXMember> members = object.members();

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXMemberHandler.java
@@ -1,10 +1,8 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.IOException;
-
 import com.dexesttp.hkxpack.data.members.HKXMember;
 import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXMemberCallback;
 
 public interface HKXMemberHandler {
-	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException;
+	public HKXMemberCallback write(HKXMember member, long currentPos);
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXMemberHandlerFactory.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXMemberHandlerFactory.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -24,11 +22,10 @@ public class HKXMemberHandlerFactory {
 
 	/**
 	 * Creates a {@link HKXMemberHandlerFactory}.
-	 * @param outFile the {@link File} to write into.
+	 * @param outFile the {@link ByteBuffer} to write into.
 	 * @param enumResolver the {@link HKXEnumResolver} to use to resolve enums.
 	 * @param data1List the list of {@link DataInternal} to fill while solving an array or a string.
 	 * @param data2List the list of {@link DataExternal} to fill while solving pointers.
-	 * @throws IOException 
 	 */
 	public HKXMemberHandlerFactory(ByteBuffer outFile, HKXEnumResolver enumResolver,
 			List<DataInternal> data1List, List<PointerObject> data2List,
@@ -42,7 +39,7 @@ public class HKXMemberHandlerFactory {
 	
 	/**
 	 * Clones the factory, but changes the memberCallback queue.
-	 * @param memberCallbacks then new {@link HKXMemberCallback} list ot use.
+	 * @param memberCallbacks then new {@link HKXMemberCallback} list to use.
 	 * @return the cloned {@link HKXMemberHandlerFactory}.
 	 */
 	public HKXMemberHandlerFactory clone(List<HKXMemberCallback> memberCallbacks) {
@@ -85,10 +82,8 @@ public class HKXMemberHandlerFactory {
 	}
 	
 	/**
-	 * Close this {@link HKXMemberHandlerFactory}.
-	 * @throws IOException if there was a problem closing the connection to the {@link File}.
+	 * @deprecated {@link ByteBuffer} usage no longer allows or requires this step
 	 */
-	/*public void close() throws IOException {
-		outFile.close();
-	}*/
+	public void close() {
+	}
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXMemberHandlerFactory.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXMemberHandlerFactory.java
@@ -1,9 +1,8 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.dexesttp.hkxpack.descriptor.HKXEnumResolver;
@@ -15,7 +14,7 @@ import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXMemberCallback;
 import com.dexesttp.hkxpack.hkxwriter.utils.PointerObject;
 
 public class HKXMemberHandlerFactory {
-	private final RandomAccessFile outFile;
+	private final ByteBuffer outFile;
 	private final HKXEnumResolver enumResolver;
 	private final List<DataInternal> data1List;
 	private final List<PointerObject> data2List;
@@ -27,16 +26,9 @@ public class HKXMemberHandlerFactory {
 	 * @param enumResolver the {@link HKXEnumResolver} to use to resolve enums.
 	 * @param data1List the list of {@link DataInternal} to fill while solving an array or a string.
 	 * @param data2List the list of {@link DataExternal} to fill while solving pointers.
-	 * @throws FileNotFoundException if there was a problem opening a conenction to the given {@link File}.
+	 * @throws IOException 
 	 */
-	public HKXMemberHandlerFactory(File outFile, HKXEnumResolver enumResolver,
-			List<DataInternal> data1List, List<PointerObject> data2List,
-			List<HKXMemberCallback> memberCallbacks)
-			throws FileNotFoundException {
-		this(new RandomAccessFile(outFile, "rw"), enumResolver, data1List, data2List, memberCallbacks);
-	}
-	
-	private HKXMemberHandlerFactory(RandomAccessFile outFile, HKXEnumResolver enumResolver,
+	public HKXMemberHandlerFactory(ByteBuffer outFile, HKXEnumResolver enumResolver,
 			List<DataInternal> data1List, List<PointerObject> data2List,
 			List<HKXMemberCallback> memberCallbacks) {
 		this.outFile = outFile;
@@ -94,7 +86,7 @@ public class HKXMemberHandlerFactory {
 	 * Close this {@link HKXMemberHandlerFactory}.
 	 * @throws IOException if there was a problem closing the connection to the {@link File}.
 	 */
-	public void close() throws IOException {
+	/*public void close() throws IOException {
 		outFile.close();
-	}
+	}*/
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXObjectMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXObjectMemberHandler.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.dexesttp.hkxpack.data.HKXObject;
@@ -19,7 +18,7 @@ public class HKXObjectMemberHandler implements HKXMemberHandler {
 	}
 
 	@Override
-	public HKXMemberCallback write(HKXMember member, final long currentPos) throws IOException {
+	public HKXMemberCallback write(HKXMember member, final long currentPos) {
 		final HKXObject object = (HKXObject) member;
 		HKXInternalObjectHandler internalObjectHandler = new HKXInternalObjectHandler(memberHandlerFactory, memberCallbacks);
 		internalObjectHandler.write(object, currentPos + offset);

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXPointerMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXPointerMemberHandler.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -18,7 +17,7 @@ public class HKXPointerMemberHandler implements HKXMemberHandler {
 	}
 
 	@Override
-	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
+	public HKXMemberCallback write(HKXMember member, long currentPos) {
 		HKXPointerMember ptrMember = (HKXPointerMember) member;
 		PointerObject ptrObject = new PointerObject();
 		ptrObject.from = currentPos + offset;

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXStringMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXStringMemberHandler.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -22,7 +21,7 @@ public class HKXStringMemberHandler implements HKXMemberHandler {
 	}
 
 	@Override
-	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
+	public HKXMemberCallback write(HKXMember member, long currentPos) {
 		final HKXStringMember strMember = (HKXStringMember) member;
 		if(strMember.get() == null || strMember.get().isEmpty())
 			return (callbacks, position) -> {return 0;};

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXStringMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/HKXStringMemberHandler.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter.object;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import com.dexesttp.hkxpack.data.members.HKXMember;
@@ -11,11 +11,11 @@ import com.dexesttp.hkxpack.hkx.data.DataInternal;
 import com.dexesttp.hkxpack.hkxwriter.object.callbacks.HKXMemberCallback;
 
 public class HKXStringMemberHandler implements HKXMemberHandler {
-	private final RandomAccessFile outFile;
+	private final ByteBuffer outFile;
 	private final long offset;
 	private final List<DataInternal> data1;
 
-	public HKXStringMemberHandler(RandomAccessFile outFile, long offset, List<DataInternal> data1List) {
+	public HKXStringMemberHandler(ByteBuffer outFile, long offset, List<DataInternal> data1List) {
 		this.outFile = outFile;
 		this.offset = offset;
 		this.data1 = data1List;
@@ -31,9 +31,9 @@ public class HKXStringMemberHandler implements HKXMemberHandler {
 		return (callbacks, position) -> { 
 			stringData.to = position;
 			data1.add(stringData);
-			outFile.seek(position);
-			outFile.writeBytes(strMember.get());
-			outFile.writeByte(0x00);
+			outFile.position((int) position);
+			outFile.put(strMember.get().getBytes());
+			outFile.put((byte) 0x00);
 			return HKXUtils.snapString(position + strMember.get().length() + 1) - position;
 		};
 	}

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/array/HKXArrayMemberHandler.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/array/HKXArrayMemberHandler.java
@@ -1,7 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.array;
 
-import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +37,7 @@ public class HKXArrayMemberHandler implements HKXMemberHandler {
 	}
 
 	@Override
-	public HKXMemberCallback write(HKXMember member, long currentPos) throws IOException {
+	public HKXMemberCallback write(HKXMember member, long currentPos) {
 		final HKXArrayMember arrMember = (HKXArrayMember) member;
 		int size = arrMember.contents().size();
 		

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXArrayMemberCallback.java
@@ -1,8 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.util.List;
 
 public interface HKXArrayMemberCallback {
-	long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException;
+	long process(List<HKXMemberCallback> memberCallbacks, long position);
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXBaseArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXBaseArrayMemberCallback.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.dexesttp.hkxpack.hkx.data.DataInternal;
@@ -17,7 +16,7 @@ public class HKXBaseArrayMemberCallback implements HKXMemberCallback {
 	}
 
 	@Override
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException {
+	public long process(List<HKXMemberCallback> memberCallbacks, long position) {
 		arrData.to = position;
 		data1.add(arrData);
 		return callbackProcessor.process(memberCallbacks, position);

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXDefaultArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXDefaultArrayMemberCallback.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.dexesttp.hkxpack.data.HKXData;
@@ -21,7 +20,7 @@ public class HKXDefaultArrayMemberCallback implements HKXArrayMemberCallback {
 	}
 
 	@Override
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException {
+	public long process(List<HKXMemberCallback> memberCallbacks, long position) {
 		long newPos = position;
 		long memberSize = MemberSizeResolver.getSize(arrMember.getSubType());
 		for(HKXData data : arrMember.contents()) {

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXMemberCallback.java
@@ -1,8 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.util.List;
 
 public interface HKXMemberCallback {
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException;
+	public long process(List<HKXMemberCallback> memberCallbacks, long position);
 }

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXObjectArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXObjectArrayMemberCallback.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +22,7 @@ public class HKXObjectArrayMemberCallback implements HKXArrayMemberCallback {
 	}
 	
 	@Override
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException {
+	public long process(List<HKXMemberCallback> memberCallbacks, long position) {
 		long newPos = position;
 		List<HKXMemberCallback> internalCallbacks = new ArrayList<>();
 		for(HKXData data : arrMember.contents()) {

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXPointerArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXPointerArrayMemberCallback.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.util.List;
 
 import com.dexesttp.hkxpack.data.members.HKXArrayMember;
@@ -18,7 +17,7 @@ public class HKXPointerArrayMemberCallback implements HKXArrayMemberCallback {
 	}
 
 	@Override
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException {
+	public long process(List<HKXMemberCallback> memberCallbacks, long position) {
 		long newPos = position;
 		for(HKXArrayPointerMemberHandler apmh : apmhList) {
 			long objectSize = MemberSizeResolver.getSize(arrMember.getSubType());

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXRelArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXRelArrayMemberCallback.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -20,7 +19,7 @@ public class HKXRelArrayMemberCallback implements HKXMemberCallback {
 	}
 
 	@Override
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException {
+	public long process(List<HKXMemberCallback> memberCallbacks, long position) {
 		byte[] offset = ByteUtils.fromLong(position - classPos, 2);
 		outFile.position((int) (classPos + argPos + 2));
 		outFile.put(offset);

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXStringArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXStringArrayMemberCallback.java
@@ -1,7 +1,7 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,9 +17,9 @@ public class HKXStringArrayMemberCallback implements HKXMemberCallback {
 	private final List<DataInternal> data1;
 	private final DataInternal arrData;
 	private final HKXArrayMember arrMember;
-	private RandomAccessFile outFile;
+	private ByteBuffer outFile;
 
-	public HKXStringArrayMemberCallback(List<DataInternal> data1, DataInternal arrData, HKXArrayMember arrMember, RandomAccessFile outFile) {
+	public HKXStringArrayMemberCallback(List<DataInternal> data1, DataInternal arrData, HKXArrayMember arrMember, ByteBuffer outFile) {
 		this.data1 = data1;
 		this.arrData = arrData;
 		this.arrMember = arrMember;
@@ -51,9 +51,9 @@ public class HKXStringArrayMemberCallback implements HKXMemberCallback {
 		return (callbacks, position) -> { 
 			stringData.to = position;
 			data1.add(stringData);
-			outFile.seek(position);
-			outFile.writeBytes(internalMember.get());
-			outFile.writeByte(0x00);
+			outFile.position((int) position);
+			outFile.put(internalMember.get().getBytes());
+			outFile.put((byte) 0x00);
 			long outSize = internalMember.get().length() + 1;
 			return outSize + ((position + outSize) % 2);
 		};

--- a/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXStringArrayMemberCallback.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/hkxwriter/object/callbacks/HKXStringArrayMemberCallback.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.hkxwriter.object.callbacks;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +24,7 @@ public class HKXStringArrayMemberCallback implements HKXArrayMemberCallback {
 	}
 
 	@Override
-	public long process(List<HKXMemberCallback> memberCallbacks, long position) throws IOException {
+	public long process(List<HKXMemberCallback> memberCallbacks, long position) {
 		long newPos = position;
 		long memberSize = MemberSizeResolver.getSize(arrMember.getSubType());
 		List<HKXMemberCallback> internalCallbacks = new ArrayList<>();

--- a/core/src/main/java/com/dexesttp/hkxpack/resources/ByteUtils.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/resources/ByteUtils.java
@@ -1,7 +1,8 @@
 package com.dexesttp.hkxpack.resources;
 
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+ 
 
 public class ByteUtils {
 	public static int getSInt(byte[] list) {
@@ -36,10 +37,10 @@ public class ByteUtils {
 		return Float.intBitsToFloat(val);
 	}
 
-	public static String readString(RandomAccessFile in) throws IOException {
+	public static String readString(ByteBuffer in) throws IOException {
 		String s = "";
 		byte b;
-		while((b = in.readByte()) != 0)
+		while((b = in.get()) != 0)
 			s += (char) b;
 		return s;
 	}

--- a/core/src/main/java/com/dexesttp/hkxpack/resources/ByteUtils.java
+++ b/core/src/main/java/com/dexesttp/hkxpack/resources/ByteUtils.java
@@ -1,6 +1,5 @@
 package com.dexesttp.hkxpack.resources;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
  
 
@@ -37,7 +36,7 @@ public class ByteUtils {
 		return Float.intBitsToFloat(val);
 	}
 
-	public static String readString(ByteBuffer in) throws IOException {
+	public static String readString(ByteBuffer in) {
 		String s = "";
 		byte b;
 		while((b = in.get()) != 0)


### PR DESCRIPTION
Dexesttp, I've done a tiny branch that just swaps out the RandomAccessFile for ByteBuffer.

This is so I can use the parser in my code, because I pull data from within nif files and also from zip streams out of the bsa and ba2 files.

The start point for the Reader and Writer still accept File and just swap to ByteBuffer quickly.

I used TestView on a few files and it seemed to read in and out fine, however the second test of reading the output xml in and creating an hkx file seems to have trouble reading the xml file (it only reads part) but this is totally untouched by my change so perhaps this is expected. That is to say the xml reading and DOM parsing is still File based.

If you want any changes or more rigorous testing I'm happy to update.

