### PR TITLE
Use explicit version

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.dexesttp</groupId>
 		<artifactId>hkxpack</artifactId>
-		<version>${project.version}</version>
+		<version>0.1.5-beta</version>
 	</parent>
 	
 	<groupId>com.dexesttp.hkxpack</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.dexesttp</groupId>
 		<artifactId>hkxpack</artifactId>
-		<version>${project.version}</version>
+		<version>0.1.5-beta</version>
 	</parent>
 	
 	<groupId>com.dexesttp.hkxpack</groupId>


### PR DESCRIPTION
## Fixes

Latest versions of mvn fail without this change, with this error:

[ERROR] [ERROR] Some problems were encountered while processing the POMs:                                               [FATAL] Non-resolvable parent POM for com.dexesttp.hkxpack:core:[unknown-version]: Failure to find com.dexesttp:hkxpack:pom:${project.version} in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at wrong local POM @ line 6, column 10

## Notes

The versions can be kept in-sync with this command:

mvn versions:set -DgenerateBackupPoms=false

See [stackoverflow](https://stackoverflow.com/questions/10582054/maven-project-version-inheritance-do-i-have-to-specify-the-parent-version) for more info.